### PR TITLE
Tighten README intro and surface contribution CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Awesome AI Startups [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-> Bootstrapped, pre-seed, and angel-funded AI products built by independent founders.
+> A curated directory of AI startups built by independent founders — bootstrapped, pre-seed, and angel-funded products from outside the big AI labs.
+
+The goal: make useful indie AI products easier to find, share, and support.
+
+**Building one?** Add your startup by opening a PR — see [contributing.md](contributing.md) for the format and inclusion criteria.
 
 ## Contents
 - [📣 Marketing, SEO & Sales](#marketing-seo-sales) (20)


### PR DESCRIPTION
## Summary
- Rewrites the intro to answer who/why/how on the first screen
- Surfaces the contribution CTA above the category index so indie founders see how to add a startup before scrolling past 400+ entries
- Keeps the existing `## Contributing` link at the bottom as a fallback

Addresses #9 (items 1 and 2). The description-polish item (#9 item 3) is a larger sweep and will be tracked separately.

## Test plan
- [ ] Render `README.md` on GitHub and confirm the new intro reads cleanly above the Contents block
- [ ] Verify the `contributing.md` link resolves