### PR TITLE
Add echo99 to Audio, Voice & Music

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 - [Backbeat Forge](https://hannes-software.com/backbeat-forge) - Drop in a full mix or an isolated drum stem.
 - [PieceKeeper](https://getpiecekeeper.com) - Never lose track of a piece again.
 - [Bolna](https://www.bolna.ai) - Bolna is a Voice AI Platform purpose-built for enterprise scale, diverse linguistic complexity, and cost sensitivity.
+- [echo99](https://www.echo99.app/) - Private Mac call recorder with on-device transcription and speaker labeling.
 
 ## 🎬 Video & Animation
 


### PR DESCRIPTION
## What changed

- Added echo99 to the end of the Audio, Voice & Music section.

## Why

echo99 is an independent, downloadable Mac call recorder that uses on-device machine learning for transcription and speaker labeling.

## Validation

- Confirmed there is no existing echo99 issue or pull request.
- Confirmed the official product page is live and supports the description.
- Confirmed only `README.md` changed.
- Confirmed the entry was appended without reordering the section.
- Ran `git diff --check`.
