### PR TITLE
Add nWave to Coding & Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 ## Contents
 - [📣 Marketing, SEO & Sales](#marketing-seo-sales) (103)
 - [🤖 AI Agents & Assistants](#ai-agents-assistants) (144)
-- [💻 Coding & Developer Tools](#coding-developer-tools) (219)
+- [💻 Coding & Developer Tools](#coding-developer-tools) (221)
 - [🎙 Audio, Voice & Music](#audio-voice-music) (62)
 - [🎬 Video & Animation](#video-animation) (50)
 - [🎨 Image, Design & 3D](#image-design-3d) (67)
@@ -501,6 +501,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 - [AgentManager](https://agentmgr.app) - A floating macOS window for every Claude Code session.
 - [OpenCode Superapp](https://opencodesuper.app) - OpenCode Superapp brings the agentic power of Codex to the models and infrastructure you choose.
 - [AskCodi](https://askcodi.com) - AskCodi orchestrates AI coding, two ways.
+- [nWave](https://nwave.ai) - AI agents that guide you from idea to working code, with you in control at every step.
 
 ## 🎙 Audio, Voice & Music
 


### PR DESCRIPTION
Adds **nWave** to the 💻 Coding & Developer Tools section.

```md
- [nWave](https://nwave.ai) - AI agents that guide you from idea to working code, with you in control at every step.
```

nWave runs inside Claude Code and breaks feature delivery into seven waves (discover, diverge, discuss, design, devops, distill, deliver), with a human review gate before each one.

**Format** — appended to the end of the section, single line, sentence-cased, linking to the canonical product page, per `contributing.md`. Nothing reordered or inserted mid-section.

**Inclusion criteria** — bootstrapped/indie (BriX Consulting), live product site, agent-based AI product an end user can install and use.

**One extra line in the diff:** the Contents count for this section read `(219)` while the section actually held 220 entries, so it now reads `(221)` to match reality after this addition rather than `(220)`. FYI the same off-by-one exists today for Image, Design & 3D (67 → 68), Analytics & Data (57 → 58) and Education & Learning (20 → 21) — left untouched here as out of scope, but worth a resync.
