### PR TITLE
docs: add Flatzer to E-commerce & Retail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1306,6 +1306,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 - [Basement Browser](https://basementbrowser.com/app) - Basement is a browser whose job is shopping.
 - [HonorBox](https://honorboxx.github.io/honorbox/) - Your storefront is a static site on GitHub Pages.
 - [Athena by Shoplazza](https://www.shoplaza.ai) - Athena helps you build a polished, launch-ready store with complete pages, products, and localized copy.
+- [Flatzer](https://flatzer.com/en) - Flatzer is ecommerce software.
 
 ## ✨ Everything Else
 


### PR DESCRIPTION
## Summary

- Add Flatzer to the **E-commerce & Retail** section.
- Use the canonical English product URL and a concise, factual description.

## Validation

- `https://flatzer.com/en` responds with HTTP 200.
- Only `README.md` is changed.
- The entry is appended to the end of the category, as required by `contributing.md`.

## Disclosure

I am affiliated with Flatzer.