### PR TITLE
Add ImageCraft Pro (Nano Banana)

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,6 +777,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 - [MascotAI](https://www.appmascot.ai) - Hey hunters!.
 - [Ctruh Studio](https://www.ctruh.com/products/studio) - Ctruh Studio is an AI-powered no-code platform that lets anyone create, customise and publish interactive 3D experiences for websites.
 - [SVG Editor - Vector Designer](https://www.vectordesigner.info) - SVG Editor - Vector Designer is a native vector graphics editor for Mac.
+- [ImageCraft Pro](https://nanobanana.live) - A browser-based AI image editor for creating and refining images with Nano Banana technology.
 
 ## ✍️ Writing & Content
 


### PR DESCRIPTION
Hi maintainers — I’m submitting ImageCraft Pro, a small independent browser-based image editor for creators who want to generate and refine images with Nano Banana technology.

It is live at https://nanobanana.live and fits the Image, Design & 3D section. I maintain the product and have kept the entry short and factual. No paid placement, reciprocal link, or badge is requested. Happy to adjust the wording if it better matches the list style.