### PR TITLE
Add Mentioned to Marketing, SEO & Sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 - [UCP Radar](https://ucpradar.com) - Your titles and descriptions were probably never written to Google's spec.
 - [The GTM Co-Founder](https://gtmcofounder.com) - Most AI hands dev-tool founders the same generic sales and marketing advice.
 - [Conference Grid](https://conferencegrid.com) - Look up any company and see every conference it sponsors, exhibits at, or speaks at — 6,000+ conferences, 62,000 speakers, 55,000 sponsor slots in one graph.
+- [Mentioned](https://mentioned.to) - Mentioned is a done-for-you Reddit growth service that finds the threads ranking on Google for your keywords and publishes native posts and comments in them.
 
 ## 🤖 AI Agents & Assistants
 


### PR DESCRIPTION
Adds one entry for **Mentioned** (https://mentioned.to) to `📣 Marketing, SEO & Sales`, appended at the end of the section to match the existing ordering.

**What it is:** it finds the Reddit threads already ranking on Google for a client's keywords (and where competitors get recommended), writes and publishes native posts and comments there from managed Reddit accounts, and reports share of voice vs competitors.

**Full disclosure, so you can judge this fairly:**
- I work on Mentioned — this is a self-submission, not a neutral third-party addition.
- It is a **paid managed service**, not self-serve software. Plans start at $2,000/month, no free tier, not open source. Founded 2025.
- This list is framed around indie AI products, and a $2,000/month managed service is a different animal from most of what's here. That's a completely fair reason to close.

I left the section count in the table of contents untouched rather than editing a second line — let me know if you'd like me to bump it. One line added otherwise.
