### PR TITLE
Add Intellrise to Analytics & Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,6 +980,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 - [Supernova](https://supernova.ai) - Supernova connects your startup’s live data to Claude and Codex, so anyone can ask questions, investigate performance, and run complex analysis in the AI tools they already use.
 - [Open Analytics](https://getopen.so) - Open Analytics is an open-source, privacy-first alternative to Google Analytics, built for humans and AI agents.
 - [Toplify](https://toplify.app) - Toplify is a multi server service monitoring App Store charts across 175 countries, 24/7, so you never miss your next milestone.
+- [Intellrise](https://intellrise.com) - Learns what your fields mean once and reuses it on later questions, then returns charts, dashboards and exportable reports; bring your own AI key.
 
 ## 🗂 Productivity & Notes
 


### PR DESCRIPTION
Adding our own product, disclosed up front: I work on Intellrise.

- **Entry:** `- [Intellrise](https://intellrise.com) - Learns what your fields mean once and reuses it on later questions, then returns charts, dashboards and exportable reports; bring your own AI key.`
- **Placement:** appended to the end of `## 📊 Analytics & Data`, after Toplify. Nothing reordered or inserted mid-section.
- **Format:** `- [Name](url) - One-line tagline.`, sentence-cased, canonical product URL, no tracking parameters.
- **Duplicate check:** `Intellrise` did not appear anywhere in README.md before this change.

Against the inclusion criteria:

- Bootstrapped, no outside funding.
- Not a big-tech subsidiary or product page.
- Anyone can sign up and use it — there is a free plan and a 14-day trial with no card.
- AI is the product, not a feature: it reads your schema, keeps what your fields mean, and writes the SQL. It runs on your own provider key (Gemini, OpenAI, Anthropic, DeepSeek, MiniMax, or any OpenAI-compatible endpoint), so there is no model markup.
- Live site, not a parked domain.

Happy to reword or shorten the description if it does not fit the list's style — and equally happy for you to close this if self-submissions are not what you are after.