### PR TITLE
Add XiuStore to E-commerce & Retail

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 - [🛠 APIs, SDKs & Infrastructure](#apis-sdks-infrastructure) (137)
 - [💬 Chatbots & Conversational](#chatbots-conversational) (30)
 - [👥 Social & Community](#social-community) (21)
-- [🛒 E-commerce & Retail](#e-commerce-retail) (15)
+- [🛒 E-commerce & Retail](#e-commerce-retail) (16)
 - [✨ Everything Else](#everything-else) (112)
 
 ## 📣 Marketing, SEO & Sales
@@ -1656,6 +1656,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 - [HonorBox](https://honorboxx.github.io/honorbox/) - Your storefront is a static site on GitHub Pages.
 - [Athena by Shoplazza](https://www.shoplaza.ai) - Athena helps you build a polished, launch-ready store with complete pages, products, and localized copy.
 - [Ask My Wardrobe](https://askmywardrobe.com) - Ask My Wardrobe is an AI outfit generator and outfit planner that makes it easier to get dressed, plan better looks, and shop with more confidence.
+- [XiuStore](https://store.xiu.ai/en/) - XiuStore is a marketplace for AI subscriptions and digital services, with buyer-visible delivery, warranty, and after-sales details.
 
 ## ✨ Everything Else
 


### PR DESCRIPTION
Adds XiuStore once at the end of E-commerce & Retail and updates the corresponding table-of-contents count. The entry describes AI subscriptions and digital services with published prices, delivery options, warranty and after-sales support.

Validation against the latest upstream: the section contains 17 entries and its count matches; removing the XiuStore row and its one-count increment reproduces the upstream README byte for byte. The product URL returns HTTP 200 and the whitespace check passes. Upstream additions remain intact.

Disclosure: I represent XiuAI and XiuLab Inc. This updates the existing submission; no paid placement or reciprocal link is requested.
