### PR TITLE
Add XiuAI to APIs, SDKs & Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 - [🎓 Education & Learning](#education-learning) (35)
 - [🩺 Health, Fitness & Wellness](#health-fitness-wellness) (37)
 - [💰 Finance, Crypto & Payments](#finance-crypto-payments) (43)
-- [🛠 APIs, SDKs & Infrastructure](#apis-sdks-infrastructure) (139)
+- [🛠 APIs, SDKs & Infrastructure](#apis-sdks-infrastructure) (140)
 - [💬 Chatbots & Conversational](#chatbots-conversational) (30)
 - [👥 Social & Community](#social-community) (21)
 - [🛒 E-commerce & Retail](#e-commerce-retail) (15)
@@ -1595,6 +1595,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 - [Dial](https://getdial.ai) - Your agent can deploy in seconds but cannot get a phone number.
 - [ARBR](https://projectarbr.org) - AI stacks are getting more complex with more models, providers, costs, and decisions.
 - [Fillo](https://fillo.so) - Build forms into your product with your coding agent.
+- [XiuAI](https://xiu.ai/en/) - XiuAI builds XiuRouter for multi-model APIs and XiuStore for AI subscriptions and digital services.
 
 ## 💬 Chatbots & Conversational
 


### PR DESCRIPTION
## Summary
- Add XiuAI to the end of the APIs, SDKs & Infrastructure section.
- Rebased onto the latest upstream main and update the section count from 139 to 140.
- Preserved upstream additions ARBR and Fillo.

XiuAI builds XiuRouter for multi-model APIs and XiuStore for AI subscriptions and digital services. The entry uses the company's canonical public page and stays concise and factual.

## Disclosure
This PR is submitted by a representative of XiuAI. XiuAI and its products are operated by XiuLab Inc, a U.S. corporation. No paid placement or reciprocal link is requested.

## Verification
- XiuAI and `xiu.ai` were not present in the upstream README or current issues/PRs before this change.
- The canonical URL returns HTTP 200.
- The conflict was resolved against the latest upstream `main`; the APIs, SDKs & Infrastructure count is now 140.
- `git diff --check` and the repository pre-push checks passed.