### PR TITLE
Add Lunalisa to Image, Design & 3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,6 +901,7 @@ The goal: make useful indie AI products easier to find, share, and support.
 - [Doop](https://doop.design) - Doop is an infinite multiplayer canvas where AI agents design beside you.
 - [Stitch AI by Dynamic Mockups](https://dynamicmockups.com/stitch/) - Stitch reads your artwork the way a professional digitizer would - planning stitch direction, density, and pull compensation region by region.
 - [CleanShot](https://getcleanshot.com) - Discover a superior way to capture your Mac's screen with built-in annotation and amazing Quick Access Overlay.
+- [Lunalisa](https://luna-lisa.art) - AI creative workspace for product photos, marketing posters, and image-to-video across 13 image and 22 video models.
 
 ## ✍️ Writing & Content
 


### PR DESCRIPTION
Lunalisa (https://luna-lisa.art) is a bootstrapped AI creative workspace for generating product photos, marketing posters, and white-background listing images from text prompts or reference media, with image-to-video extension across 13 image models and 22 video models. Freemium pricing, free credits on signup. Appended to the end of the Image, Design & 3D section per CONTRIBUTING.md.